### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: Build
 on: push
+permissions:
+  contents: read
 
 jobs:
   verify:


### PR DESCRIPTION
Potential fix for [https://github.com/paderinandrey/ruby-on-roda/security/code-scanning/1](https://github.com/paderinandrey/ruby-on-roda/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the workflow's steps, it primarily needs to read repository contents (e.g., to check out code). Therefore, we will set `contents: read` as the permission. This ensures that the workflow does not have unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
